### PR TITLE
Work with enonic 7.9 + updated CSP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ Easy to set up and use security headers for Enonic XP.
 The application is available through [Enonic Market](https://market.enonic.com/vendors/bouvet/security-headers).
 
 ### Install application
+#### Enonic Market
 Open the Applications section of your Enonic XP installation. Click 'Install', 
 and locate the 'Security Headers' app in the 'Enonic Market' tab. Now click the 'Install'
 button.
+
+#### Build yourself
+Build this app with gradle. In the terminal, from the root of the project, enter `./gradlew build`. On Windows, just enter `gradlew build`
+in the command line from the project root. Next, move the JAR file from build/libs to your `$XP_HOME/deploy` directory. The Security.txt
+app will now be available to add to your websites through the Content Manager app.
 
 ### Apply the application to your site
 Edit your site settings by clicking 'edit' on the site node in Content Manager. Select 'Security Headers'
@@ -94,7 +100,4 @@ The Referrer-Policy HTTP header governs which referrer information, sent in the 
 Updated so the CSP from this app overwrites the default CSP from Enonic, which was implemented from Enonic XP 7.9.0 (https://developer.enonic.com/docs/xp/stable/release#xp7_update_9).
 Enonic added CSP to preview, but this app did not add Security Headers to edit or preview mode, so it was changed to add it to preview mode as well so the site won't behave 
 differently from preview to live if you use this app.
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,26 @@ The Referrer-Policy HTTP header governs which referrer information, sent in the 
 
 ## Changelog
 ### 3.0.0
-Updated so the CSP from this app overwrites the default CSP from Enonic, which was implemented from Enonic XP 7.9.0 (https://developer.enonic.com/docs/xp/stable/release#xp7_update_9).
-Enonic added CSP to preview, but this app did not add Security Headers to edit or preview mode, so it was changed to add it to preview mode as well so the site won't behave 
-differently from preview to live if you use this app.
 
+Breaking change: CSP field is updated. See details of how to update from older versions below.
+
+After Enonic added CSP to the preview mode with Enonic XP 7.9.0 (https://developer.enonic.com/docs/xp/stable/release#xp7_update_9),
+we needed to update this app to also add the CSP to preview mode, so the user won't be confused by possible different CSPs. Therefore this app will
+now add Security Headers to any mode except edit mode.
+
+The CSP input in this app has also been updated to make it easier to maintain.
+
+#### Updating to 3.0.0 from older versions:
+- If you are only using the config file: this update should not affect you. But, we found the documentation gave the wrong filename for the config file, 
+  so you might check that your config is saved in '$XP_HOME/config/no.bouvet.app.securityheaders.cfg' to make sure it is in use.
+- If you are using the "Content-Security-Policy" field, you should: 
+  1. Copy your CSP to a safe place. If you have already updated and did not save your CSP somewhere else,
+    you will still be able to find your old CSP by using for example "Content Viewer", and finding the old config below `data.config.contentSecurityPolicy.policy`.
+    
+     ***NOTE:*** this policy will not be used even if you can still find it in your content. 
+  2. Update the app by opening the Applications section of your Enonic XP installation. Click 'Install', and locate the 'Security Headers' app
+    in the 'Enonic Market' tab. Now click the 'Update' button.
+  3. Navigate to Content Studio and edit the Site Configuration of the "Security Headers" app, and add your CSP by
+    checking the "Common Directives" you want to use and edit their values as you need. If you can't find one of the directives you want to use here, 
+    you can add them by adding one or more "Extra directives".
+- If you are using anything else than what is mentioned above, your settings will not change by this update. The only change will be that the settings are also added to preview mode.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ configuration file.
 
 #### Configuration file
 If you check the 'Use configuration from file [...]' radio button, Security Headers will load its
-configuration from a configuration file located in '$XP_HOME/config/no.bouvet.app.security-headers.cfg'
+configuration from a configuration file located in '$XP_HOME/config/no.bouvet.app.securityheaders.cfg'
 instead of using the options specified in the application's site configuration.
 
 The values for each header will be used exactly as specified in the configuration file. Because of this,

--- a/README.md
+++ b/README.md
@@ -83,9 +83,17 @@ The Referrer-Policy HTTP header governs which referrer information, sent in the 
 ### Links
 [Test your site at securityheaders.io](https://securityheaders.io/)
 
+## Compatibility
+| App version | XP version |
+|-------------|------------|
+| 3.x.x       | 7.9.x      |
+| 2.x.x       | 7.x.x      |
 
-
-
+## Changelog
+### 3.0.0
+Updated so the CSP from this app overwrites the default CSP from Enonic, which was implemented from Enonic XP 7.9.0 (https://developer.enonic.com/docs/xp/stable/release#xp7_update_9).
+Enonic added CSP to preview, but this app did not add Security Headers to edit or preview mode, so it was changed to add it to preview mode as well so the site won't behave 
+differently from preview to live if you use this app.
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ appName = no.bouvet.app.securityheaders
 displayName = Security Headers
 vendorName = Bouvet
 vendorUrl = http://www.bouvet.no
-xpVersion = 7.0.0
-version = 2.0.0
+xpVersion = 7.9.0
+version = 3.0.0

--- a/src/main/resources/lib/project-util.js
+++ b/src/main/resources/lib/project-util.js
@@ -1,0 +1,16 @@
+/*
+*   Simple utility function for forcing something to be an array
+*
+*   Call by using forceArray(object)
+*   forceArray will always return an array.
+*   If the object we are forcing is undefined,
+*   the returned array will be empty
+*/
+exports.forceArray = function (object){
+  if (!object || (typeof object === 'object' && !Object.keys(object).length)) {
+    return [];
+  } else if (object.constructor !== Array || typeof object === 'string') {
+    return [object];
+  }
+  return object;
+};

--- a/src/main/resources/site/filters/security-headers.js
+++ b/src/main/resources/site/filters/security-headers.js
@@ -2,7 +2,7 @@ var portalLib = require('/lib/xp/portal');
 
 exports.responseFilter = function (req, res) {
     // Do not apply security headers when in live edit.
-    if (req.mode == 'edit' || req.mode == 'preview') return res;
+    if (req.mode == 'edit') return res;
 
     var headers = res.headers;
     var siteConfig = portalLib.getSiteConfig();

--- a/src/main/resources/site/filters/security-headers.js
+++ b/src/main/resources/site/filters/security-headers.js
@@ -1,13 +1,14 @@
 var portalLib = require('/lib/xp/portal');
+var utilLib = require('/lib/project-util');
 
 exports.responseFilter = function (req, res) {
     // Do not apply security headers when in live edit.
-    if (req.mode == 'edit') return res;
+    if (req.mode === 'edit') return res;
 
     var headers = res.headers;
     var siteConfig = portalLib.getSiteConfig();
 
-    if (siteConfig && siteConfig.useConfigFile == true) {
+    if (siteConfig && siteConfig.useConfigFile === true) {
         if (app.config.header_strict_transport_security)    headers["Strict-Transport-Security"]    = app.config.header_strict_transport_security;
         if (app.config.header_content_security_policy)      headers["Content-Security-Policy"]      = app.config.header_content_security_policy;
         if (app.config.header_x_frame_options)              headers["X-Frame-Options"]              = app.config.header_x_frame_options;
@@ -24,8 +25,32 @@ exports.responseFilter = function (req, res) {
             headers["Strict-Transport-Security"] = h;
         }
 
-        if (siteConfig.contentSecurityPolicy) {
-            headers["Content-Security-Policy"] = siteConfig.contentSecurityPolicy.policy;
+        if (siteConfig.contentSecurityPolicy
+          && ((siteConfig.contentSecurityPolicy.commonDirectives && siteConfig.contentSecurityPolicy.commonDirectives._selected)
+          || (siteConfig.contentSecurityPolicy.extraDirectives))
+        ) {
+            var h = '';
+            var selectedCommonDirectives = utilLib.forceArray(siteConfig.contentSecurityPolicy.commonDirectives._selected);
+            if (selectedCommonDirectives.length > 0) {
+                selectedCommonDirectives.forEach(function (selectedCommonDirective) {
+                    if (siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective] && siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective].directiveValues) {
+                        h += `${selectedCommonDirective} ${siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective].directiveValues};`;
+                    }
+                });
+            }
+
+            var extraDirectives = utilLib.forceArray(siteConfig.contentSecurityPolicy.extraDirectives);
+            if (extraDirectives.length > 0) {
+                extraDirectives.forEach(function (extraDirective) {
+                    if (extraDirective.directiveName && extraDirective.directiveValues){
+                        h += `${extraDirective.directiveName} ${extraDirective.directiveValues};`;
+                    }
+                })
+            }
+
+            if (h.length > 0) {
+                headers["Content-Security-Policy"] = h;
+            }
         }
 
         if (siteConfig.xFrameOptions) {

--- a/src/main/resources/site/processors/security-headers.js
+++ b/src/main/resources/site/processors/security-headers.js
@@ -2,7 +2,7 @@ var portalLib = require('/lib/xp/portal');
 
 exports.responseProcessor = function (req, res) {
     // Do not apply security headers when in live edit.
-    if (req.mode == 'edit' || req.mode == 'preview') return res;
+    if (req.mode == 'edit') return res;
 
     var headers = res.headers;
     var siteConfig = portalLib.getSiteConfig();

--- a/src/main/resources/site/processors/security-headers.js
+++ b/src/main/resources/site/processors/security-headers.js
@@ -1,13 +1,14 @@
 var portalLib = require('/lib/xp/portal');
+var utilLib = require('/lib/project-util');
 
 exports.responseProcessor = function (req, res) {
     // Do not apply security headers when in live edit.
-    if (req.mode == 'edit') return res;
+    if (req.mode === 'edit') return res;
 
     var headers = res.headers;
     var siteConfig = portalLib.getSiteConfig();
 
-    if (siteConfig && siteConfig.useConfigFile == true) {
+    if (siteConfig && siteConfig.useConfigFile === true) {
         if (app.config.header_strict_transport_security)    headers["Strict-Transport-Security"]    = app.config.header_strict_transport_security;
         if (app.config.header_content_security_policy)      headers["Content-Security-Policy"]      = app.config.header_content_security_policy;
         if (app.config.header_x_frame_options)              headers["X-Frame-Options"]              = app.config.header_x_frame_options;
@@ -24,8 +25,32 @@ exports.responseProcessor = function (req, res) {
             headers["Strict-Transport-Security"] = h;
         }
 
-        if (siteConfig.contentSecurityPolicy) {
-            headers["Content-Security-Policy"] = siteConfig.contentSecurityPolicy.policy;
+        if (siteConfig.contentSecurityPolicy
+          && ((siteConfig.contentSecurityPolicy.commonDirectives && siteConfig.contentSecurityPolicy.commonDirectives._selected)
+          || (siteConfig.contentSecurityPolicy.extraDirectives))
+        ) {
+            var h = '';
+            var selectedCommonDirectives = utilLib.forceArray(siteConfig.contentSecurityPolicy.commonDirectives._selected);
+            if (selectedCommonDirectives.length > 0) {
+                selectedCommonDirectives.forEach(function (selectedCommonDirective) {
+                    if (siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective] && siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective].directiveValues) {
+                        h += `${selectedCommonDirective} ${siteConfig.contentSecurityPolicy.commonDirectives[selectedCommonDirective].directiveValues};`;
+                    }
+                });
+            }
+
+            var extraDirectives = utilLib.forceArray(siteConfig.contentSecurityPolicy.extraDirectives);
+            if (extraDirectives.length > 0) {
+                extraDirectives.forEach(function (extraDirective) {
+                    if (extraDirective.directiveName && extraDirective.directiveValues){
+                        h += `${extraDirective.directiveName} ${extraDirective.directiveValues};`;
+                    }
+                })
+            }
+
+            if (h.length > 0) {
+                headers["Content-Security-Policy"] = h;
+            }
         }
 
         if (siteConfig.xFrameOptions) {

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -58,7 +58,7 @@
                       <option name="base-uri">
                           <label>base-uri</label>
                           <default>true</default>
-                          <help-text>Restricts the URLs which can be used in a document's "base" element. Not setting this allows any URL (no fallback).</help-text>
+                          <help-text>Restricts the URLs which can be used in a document's &lt;base&gt; element. Not setting this allows any URL (no fallback).</help-text>
                           <items>
                               <input name="directiveValues" type="TextArea">
                                   <label>Directive values</label>
@@ -80,7 +80,7 @@
                       <option name="object-src">
                           <label>object-src</label>
                           <default>true</default>
-                          <help-text>Specifies valid sources for the "object", "embed", and "applet" elements. Defaults back to default-src, but it is recommended to restrict this fetch-directive (e.g. explicitly set object-src 'none' if possible) as elements controlled by object-src are perhaps coincidentally considered legacy HTML elements and aren't receiving new standardized features (such as the security attributes sandbox or allow for "iframe"). See more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src</help-text>
+                          <help-text>Specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements. Defaults back to default-src, but it is recommended to restrict this fetch-directive (e.g. explicitly set object-src 'none' if possible) as elements controlled by object-src are perhaps coincidentally considered legacy HTML elements and aren't receiving new standardized features (such as the security attributes sandbox or allow for &lt;iframe&gt;). See more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src</help-text>
                           <items>
                               <input name="directiveValues" type="TextArea">
                                   <label>Directive values</label>
@@ -170,12 +170,15 @@
           <options minimum="1" maximum="1">
               <option name="deny">
                   <label>DENY</label>
+                  <help-text>The page can only be displayed in a frame on the same origin as the page itself.</help-text>
               </option>
               <option name="sameorigin">
                   <label>SAMEORIGIN</label>
+                  <help-text>The page cannot be displayed in a frame, regardless of the site attempting to do so.</help-text>
               </option>
               <option name="allowFrom">
                   <label>ALLOW-FROM</label>
+                  <help-text>Obsolete directive that no longer works in modern browsers. From MDN link (see help-text for X-Frame-Options): "Don't use it."</help-text>
                   <items>
                       <input name="uri" type="TextLine">
                           <label>ALLOW-FROM uri</label>
@@ -191,20 +194,24 @@
           <label>X-XSS-Protection</label>
           <expanded>true</expanded>
           <occurrences minimum="0" maximum="1"/>
-          <help-text>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. Although these protections are largely unnecessary in modern browsers when sites implement a strong Content-Security-Policy that disables the use of inline JavaScript ('unsafe-inline'), they can still provide protections for users of older web browsers that don't yet support CSP. Full description of all the options at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection</help-text>
+          <help-text>If you do not need to support legacy browsers, it is recommended that you use Content-Security-Policy without allowing unsafe-inline scripts instead of using this, as "XSS protection can create XSS vulnerabilities in otherwise safe websites" - see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection.The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. Although these protections are largely unnecessary in modern browsers when sites implement a strong Content-Security-Policy that disables the use of inline JavaScript ('unsafe-inline'), they can still provide protections for users of older web browsers that don't yet support CSP.</help-text>
           <options minimum="1" maximum="1">
               <option name="xss_0">
                   <label>Disabled (0)</label>
+                  <help-text>Disables XSS filtering</help-text>
               </option>
               <option name="xss_1">
                   <label>Enabled (1)</label>
+                  <help-text>Enables XSS filtering (usually default in browsers). If a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</help-text>
                   <default>true</default>
               </option>
               <option name="xss_1_block">
                   <label>Enabled, block mode (1; mode=block)</label>
+                  <help-text>Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.</help-text>
               </option>
               <option name="xss_1_report">
                   <label>Enabled, report mode (1; report=report_url) (Chromium only)</label>
+                  <help-text>Enables XSS filtering. If a cross-site scripting attack is detected, the browser will sanitize the page and report the violation. This uses the functionality of the CSP report-uri directive to send a report.</help-text>
                   <items>
                       <input name="url" type="TextLine">
                           <label>Report URL</label>

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -37,14 +37,128 @@
 
       <item-set name="contentSecurityPolicy">
           <label>Content-Security-Policy</label>
-          <help-text>Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware.</help-text>
+          <help-text>Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. Read more about CSP at https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP .</help-text>
           <occurrences minimum="0" maximum="1"/>
           <items>
-              <input name="policy" type="TextLine">
-                  <label>Content-Security-Policy</label>
-                  <help-text>Read more about CSP at https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP</help-text>
-                  <default>default-src 'self'</default>
-              </input>
+              <option-set name="commonDirectives">
+                  <label>Common Directives</label>
+                  <occurrences minimum="1" maximum="1"/>
+                  <options minimum="0" maximum="0">
+                      <option name="default-src">
+                          <label>default-src</label>
+                          <default>true</default>
+                          <help-text>Serves as a fallback for the other fetch directives. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src</help-text>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="base-uri">
+                          <label>base-uri</label>
+                          <default>true</default>
+                          <help-text>Restricts the URLs which can be used in a document's "base" element. Not setting this allows any URL (no fallback).</help-text>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="form-action">
+                          <label>form-action</label>
+                          <default>true</default>
+                          <help-text>Restricts the URLs which can be used as the target of a form submissions from a given context. Not setting this allows anything (no fallback). Warning: Whether form-action should block redirects after a form submission is debated and browser implementations of this aspect are inconsistent. See more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action</help-text>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="object-src">
+                          <label>object-src</label>
+                          <default>true</default>
+                          <help-text>Specifies valid sources for the "object", "embed", and "applet" elements. Defaults back to default-src, but it is recommended to restrict this fetch-directive (e.g. explicitly set object-src 'none' if possible) as elements controlled by object-src are perhaps coincidentally considered legacy HTML elements and aren't receiving new standardized features (such as the security attributes sandbox or allow for "iframe"). See more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src</help-text>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'none'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="script-src">
+                          <label>script-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="font-src">
+                          <label>font-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self' data:</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="frame-src">
+                          <label>frame-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="img-src">
+                          <label>img-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self' data:</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="media-src">
+                          <label>media-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self' data:</default>
+                              </input>
+                          </items>
+                      </option>
+                      <option name="style-src">
+                          <label>style-src</label>
+                          <items>
+                              <input name="directiveValues" type="TextArea">
+                                  <label>Directive values</label>
+                                  <default>'self'</default>
+                              </input>
+                          </items>
+                      </option>
+                  </options>
+              </option-set>
+
+              <item-set name="extraDirectives">
+                  <label>Extra directives</label>
+                  <occurrences minimum="0" maximum="0"/>
+                  <items>
+                      <input name="directiveName" type="TextLine">
+                          <label>Directive Name</label>
+                          <occurrences minimum="0" maximum="1"/>
+                      </input>
+                      <input name="directiveValues" type="TextArea">
+                          <label>Directive Values</label>
+                          <occurrences minimum="0" maximum="1"/>
+                      </input>
+                  </items>
+              </item-set>
           </items>
       </item-set>
 


### PR DESCRIPTION
After Enonic added CSP to the preview mode with Enonic XP 7.9.0, we needed to update this app to also add the CSP to preview mode, so the user won't be confused by possible different CSPs.
The useConfigFile did not work when using the file `'$XP_HOME/config/no.bouvet.app.security-headers.cfg'` from the Readme, so updated readme to refer to the file which will make it work: `'$XP_HOME/config/no.bouvet.app.securityheaders.cfg'`.
The old TextLine for the CSP config is replaced.

Note: In the CSP config, we use `<default>true</default>` for some of the options. At the moment these do not work (https://github.com/enonic/app-contentstudio/issues/4629) but it can be useful when it works again.

Fixes #5