### PR TITLE
maintenance/BOUENO-79: Changed values in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 3.1.0
 
 # XP App values
 displayName = Security Headers
-appName = com.github.bouvet-apps.security-headers
+appName = no.bouvet.app.securityheaders
 vendorName = Bouvet
 vendorUrl = http://www.bouvet.no
 xpVersion = 7.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 # Gradle Project settings
-projectName = securityheaders
+projectName = security-headers
 version = 3.1.0
 
 # XP App values
 displayName = Security Headers
-appName = no.bouvet.app.securityheaders
+appName = com.github.bouvet-apps.security-headers
 vendorName = Bouvet
 vendorUrl = http://www.bouvet.no
 xpVersion = 7.9.0
 
 # Settings for publishing to a Maven repo
-group = no.bouvet.exp
+group = com.github.bouvet-apps


### PR DESCRIPTION
According to the support case it seems like appName should be changed to group + projectName which needs to be com.github.userName + repoName according to jitpack docs.